### PR TITLE
#8: Initial work to provide a schema.cql as input

### DIFF
--- a/helm/cassandra-quality/templates/schema-configmap.yaml
+++ b/helm/cassandra-quality/templates/schema-configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: schema-configmap
+  namespace: {{ .Values.namespace }}
+data:
+  schema.cql: |-
+{{ .Values.cql_schema | indent 4}}

--- a/helm/cassandra-quality/templates/schema-job.yaml
+++ b/helm/cassandra-quality/templates/schema-job.yaml
@@ -1,0 +1,46 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: schema-job
+  namespace: {{ .Values.namespace }}
+spec:
+  templates:
+  - name: configure-schema
+    container:
+      image: alpine
+      command: ["sh", "-c", "-e"]
+      args:
+        - VERSION=$(wget -q -O - https://storage.googleapis.com/kubernetes-release/release/stable.txt 2> /dev/null);
+          wget -q -O /usr/sbin/kubectl https://storage.googleapis.com/kubernetes-release/release/$VERSION/bin/linux/amd64/kubectl;
+          chmod +x /usr/sbin/kubectl;
+          echo "Configuring schema on the source cluster...";
+          cat /schema/schema.cql | kubectl exec -n {{ .Values.namespace }} -i -t -c cassandra {{ .Values.source.clusterName }}-{{ .Values.source.dc }}-default-sts-0 -- sh -c "cqlsh -u {{ .Values.source.clusterName }}-superuser -p $(cat /secret-source/password)";
+          echo "Configuring schema on the target cluster...";
+          cat /schema/schema.cql | kubectl exec -n {{ .Values.namespace }} -i -t -c cassandra {{ .Values.target.clusterName }}-{{ .Values.target.dc }}-default-sts-0 -- sh -c "cqlsh -u {{ .Values.target.clusterName }}-superuser -p $(cat /secret-target/password)";
+          echo "Done";
+      volumeMounts:
+        - name: schema
+          mountPath: /schema
+          readOnly: true
+        - name: target-secret-volume
+          mountPath: /secret-target
+          readOnly: true
+        - name: source-secret-volume
+          mountPath: /secret-source
+          readOnly: true
+    volumes:
+    - name: schema
+      configMap:
+        name: schema-configmap
+    - name: source-secret-volume
+      secret:
+        secretName: {{ .Values.source.clusterName }}-superuser
+        items:
+        - key: password
+          path: password
+    - name: target-secret-volume
+      secret:
+        secretName: {{ .Values.target.clusterName }}-superuser
+        items:
+        - key: password
+          path: password

--- a/helm/cassandra-quality/templates/workflow-nosqlbench-cassdiff.yaml
+++ b/helm/cassandra-quality/templates/workflow-nosqlbench-cassdiff.yaml
@@ -26,6 +26,11 @@ spec:
         templateRef:
           name: spark-image
           template: spark-image-template
+      - name: configure-schema
+        depends: "cassandra-ready"
+        templateRef:
+          name: schema-job
+          template: configure-schema
       - name: nosqlbench-source
         depends: "cassandra-ready"
         templateRef:

--- a/helm/cassandra-quality/values.yaml
+++ b/helm/cassandra-quality/values.yaml
@@ -47,6 +47,17 @@ cassandra_diff_config:
     ttl: 31536000
     should_init: true
 
+cql_schema: |-
+  CREATE KEYSPACE IF NOT EXISTS testkeyspace
+    WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'}
+    AND durable_writes = true;
+
+  CREATE TABLE IF NOT EXISTS testkeyspace.testtable (
+    key text,
+    value text,
+    PRIMARY KEY (key)
+  );
+
 nosqlbench_workload: |-
   scenarios:
     default:


### PR DESCRIPTION
rom what I've seen, there are many ways I could have done this task so I hope this one is an appropriate one. This PR allows us to specify an alternative cql schema as input, which will be applied in the source and target clusters using cqlsh.

cli:
`helm install cassandra-quality helm/cassandra-quality -n cass-operator -f myvalues.yaml`