### PR TITLE
Adding sysprop to Maven invocation to avoid running tests on cassandra-diff build

### DIFF
--- a/helm/adelphi/templates/spark-image-builder.yaml
+++ b/helm/adelphi/templates/spark-image-builder.yaml
@@ -38,6 +38,7 @@ spec:
         - mvn
         - clean
         - package
+        - -DskipTests=true
       volumeMounts:
       - name: download
         mountPath: /download


### PR DESCRIPTION
Minor change to avoid running tests on cassandra-diff at build time.  Since this is a known version running the tests here aren't very useful and just add extra running time.

We probably should checkout an explicit "known good" git commit as well but I held off on that for now pending additional conversations.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1198513180644180/1198939413771615) by [Unito](https://www.unito.io/learn-more)
