### PR TITLE
#74 Metadata reform

### DIFF
--- a/python/adelphi/adelphi/__init__.py
+++ b/python/adelphi/adelphi/__init__.py
@@ -1,0 +1,17 @@
+# Copyright DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class NoKeyspacesSelectedException(Exception):
+    """Exception indicinating that no valid keyspaces were selected"""
+    pass

--- a/python/adelphi/adelphi/cql.py
+++ b/python/adelphi/adelphi/cql.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-# Logic necessary to generate a string representation of a standard CQL schema
+import json
 
 from adelphi.export import BaseExporter
 from adelphi.store import set_replication_factor
@@ -27,9 +27,11 @@ class CqlExporter(BaseExporter):
         self.metadata = self.get_common_metadata(cluster, props)
 
 
-    def each_keyspace(self, ks_fn):
-        for (ks, keyspace_id) in self.keyspaces.items():
-            ks_fn(ks, keyspace_id)
+    def export_all(self):
+        metadata_str = json.dumps(self.export_metadata(), indent=4)
+        metadata_comments = "\n".join("//{}".format(line).strip() for line in metadata_str.splitlines())
+
+        return metadata_comments + "\n\n" + self.export_schema()
 
 
     def export_metadata(self):
@@ -49,6 +51,11 @@ class CqlExporter(BaseExporter):
                       .replace("CREATE KEYSPACE", "CREATE KEYSPACE IF NOT EXISTS") \
                       .replace("CREATE TYPE", "CREATE TYPE IF NOT EXISTS") \
                       .replace("CREATE INDEX", "CREATE INDEX IF NOT EXISTS")
+
+
+    def each_keyspace(self, ks_fn):
+        for (ks, keyspace_id) in self.keyspaces.items():
+            ks_fn(ks, keyspace_id)
 
 
     def add_metadata(self, k, v):

--- a/python/adelphi/adelphi/cql.py
+++ b/python/adelphi/adelphi/cql.py
@@ -15,25 +15,120 @@
 
 # Logic necessary to generate a string representation of a standard CQL schema
 
+import hashlib
+import logging
+from base64 import urlsafe_b64encode
+from datetime import datetime, tzinfo, timedelta
+
+try:
+    from itertools import ifilterfalse as filterfalse
+except ImportError:
+    from itertools import filterfalse
+
+try:
+    from datetime import timezone
+    utc = timezone.utc
+except ImportError:
+    class UTC(tzinfo):
+        def utcoffset(self, dt):
+            return timedelta(0)
+        def tzname(self, dt):
+            return "UTC"
+        def dst(self, dt):
+            return timedelta(0)
+    utc = UTC()
+
+
 from adelphi.anonymize import anonymize_keyspace
-from adelphi.store import set_replication_factor
+from adelphi.store import build_keyspace_objects, set_replication_factor
 
-def export_cql_schema(keyspace_objs_iter, metadata, options):
 
-    # set replication factor
-    set_replication_factor(keyspace_objs_iter, options['rf'])
+log = logging.getLogger('adelphi')
 
-    metadata_generator = ("//@{} = {}".format(k,v) for k,v in metadata.items())
-    metadata_str = "//Schema metadata:\n" + "\n".join(metadata_generator)
+class NoKeyspacesSelectedException(Exception):
+    """Exception indicinating that no valid keyspaces were selected"""
+    pass
 
-    # build CQL statements string
-    cql_str = "\n\n".join(ks.export_as_string() for ks in keyspace_objs_iter)
 
-    # transform CREATE statements to include `IF NOT EXISTS`
-    # TODO: shift this around to a regex so that we can do the whole thing in a single pass
-    cql_str = cql_str.replace("CREATE TABLE", "CREATE TABLE IF NOT EXISTS") \
-        .replace("CREATE KEYSPACE", "CREATE KEYSPACE IF NOT EXISTS") \
-        .replace("CREATE TYPE", "CREATE TYPE IF NOT EXISTS") \
-        .replace("CREATE INDEX", "CREATE INDEX IF NOT EXISTS")
+class CqlExporter:
 
-    return metadata_str + "\n\n" + cql_str
+    def __init__(self, cluster, props):
+        self.props = props
+
+        self.keyspaces = self.__get_keyspaces(cluster, props)
+
+        self.metadata = {k : props[k] for k in ["purpose", "maturity"] if k in props}
+        self.metadata.update(self.__get_cluster_metadata(cluster))
+        self.metadata["creation_timestamp"] = datetime.now(utc).isoformat()
+
+
+    # unique_everseen from itertools recipes
+    def __unique(self, iterable, key=None):
+        "List unique elements, preserving order. Remember all elements ever seen."
+        # unique_everseen('AAAABBBCCDAABBB') --> A B C D
+        # unique_everseen('ABBCcAD', str.lower) --> A B C D
+        seen = set()
+        seen_add = seen.add
+        if key is None:
+            for element in filterfalse(seen.__contains__, iterable):
+                seen_add(element)
+                yield element
+        else:
+            for element in iterable:
+                k = key(element)
+                if k not in seen:
+                    seen_add(k)
+                    yield element
+
+
+    def __build_keyspace_id(self, ks):
+        m = hashlib.sha256()
+        m.update(ks.name.encode("utf-8"))
+        # Leverage the urlsafe base64 encoding defined in RFC 4648, section 5 to provide an ID which can
+        # safely be used for filenames as well
+        return urlsafe_b64encode(m.digest()).decode('ascii')
+
+
+    def __get_keyspaces(self, cluster, props):
+        keyspace_names = props["keyspace-names"]
+        metadata = cluster.metadata
+        keyspaces = build_keyspace_objects(keyspace_names, metadata)
+
+        if len(keyspaces) == 0:
+            raise NoKeyspacesSelectedException
+
+        log.info("Processing the following keyspaces: %s", ','.join((ks.name for ks in keyspaces)))
+
+        # anonymize_keyspace mutates keyspace state so we must trap keyspace_id before we (possibly) call it
+        base_map = { ks : self.__build_keyspace_id(ks) for ks in keyspaces}
+        return base_map if not props['anonymize'] else {anonymize_keyspace(ks) : keyspace_id for (ks, keyspace_id) in base_map.items()}
+
+
+    def __get_cluster_metadata(self, cluster):
+        hosts = cluster.metadata.all_hosts()
+        unique_dcs = self.__unique((host.datacenter for host in hosts))
+        return {"host-count": len(hosts), "dc-count": sum(1 for i in unique_dcs)}
+
+
+    def each_keyspace(self, ks_fn):
+        for (ks, keyspace_id) in self.keyspaces.items():
+            ks_fn(ks, keyspace_id)
+
+
+    def export_metadata(self):
+        return {k : self.metadata[k] for k in self.metadata.keys() if self.metadata[k]}
+
+
+    def export_schema(self):
+
+        set_replication_factor(self.keyspaces, self.props['rf'])
+
+        # build CQL statements string
+        cql_str = "\n\n".join(ks.export_as_string() for ks in self.keyspaces)
+
+        # transform CREATE statements to include `IF NOT EXISTS`
+        # TODO: shift this around to a regex so that we can do the whole thing in a single pass
+        return cql_str.replace("CREATE TABLE", "CREATE TABLE IF NOT EXISTS") \
+                      .replace("CREATE KEYSPACE", "CREATE KEYSPACE IF NOT EXISTS") \
+                      .replace("CREATE TYPE", "CREATE TYPE IF NOT EXISTS") \
+                      .replace("CREATE INDEX", "CREATE INDEX IF NOT EXISTS")

--- a/python/adelphi/adelphi/cql.py
+++ b/python/adelphi/adelphi/cql.py
@@ -15,104 +15,16 @@
 
 # Logic necessary to generate a string representation of a standard CQL schema
 
-import hashlib
-import logging
-from base64 import urlsafe_b64encode
-from datetime import datetime, tzinfo, timedelta
-
-try:
-    from itertools import ifilterfalse as filterfalse
-except ImportError:
-    from itertools import filterfalse
-
-try:
-    from datetime import timezone
-    utc = timezone.utc
-except ImportError:
-    class UTC(tzinfo):
-        def utcoffset(self, dt):
-            return timedelta(0)
-        def tzname(self, dt):
-            return "UTC"
-        def dst(self, dt):
-            return timedelta(0)
-    utc = UTC()
+from adelphi.export import BaseExporter
+from adelphi.store import set_replication_factor
 
 
-from adelphi.anonymize import anonymize_keyspace
-from adelphi.store import build_keyspace_objects, set_replication_factor
-
-
-log = logging.getLogger('adelphi')
-
-class NoKeyspacesSelectedException(Exception):
-    """Exception indicinating that no valid keyspaces were selected"""
-    pass
-
-
-class CqlExporter:
+class CqlExporter(BaseExporter):
 
     def __init__(self, cluster, props):
         self.props = props
-
-        self.keyspaces = self.__get_keyspaces(cluster, props)
-
-        self.metadata = {k : props[k] for k in ["purpose", "maturity"] if k in props}
-        self.metadata.update(self.__get_cluster_metadata(cluster))
-        self.metadata["creation_timestamp"] = datetime.now(utc).isoformat()
-
-
-    # unique_everseen from itertools recipes
-    def __unique(self, iterable, key=None):
-        "List unique elements, preserving order. Remember all elements ever seen."
-        # unique_everseen('AAAABBBCCDAABBB') --> A B C D
-        # unique_everseen('ABBCcAD', str.lower) --> A B C D
-        seen = set()
-        seen_add = seen.add
-        if key is None:
-            for element in filterfalse(seen.__contains__, iterable):
-                seen_add(element)
-                yield element
-        else:
-            for element in iterable:
-                k = key(element)
-                if k not in seen:
-                    seen_add(k)
-                    yield element
-
-
-    def __build_keyspace_id(self, ks):
-        m = hashlib.sha256()
-        m.update(ks.name.encode("utf-8"))
-        # Leverage the urlsafe base64 encoding defined in RFC 4648, section 5 to provide an ID which can
-        # safely be used for filenames as well
-        return urlsafe_b64encode(m.digest()).decode('ascii')
-
-
-    def __get_keyspaces(self, cluster, props):
-        keyspace_names = props["keyspace-names"]
-        metadata = cluster.metadata
-        keyspaces = build_keyspace_objects(keyspace_names, metadata)
-
-        if len(keyspaces) == 0:
-            raise NoKeyspacesSelectedException
-
-        log.info("Processing the following keyspaces: %s", ','.join((ks.name for ks in keyspaces)))
-
-        # anonymize_keyspace mutates keyspace state so we must trap keyspace_id before we (possibly) call it
-        base_map = { ks : self.__build_keyspace_id(ks) for ks in keyspaces}
-        return base_map if not props['anonymize'] else {anonymize_keyspace(ks) : keyspace_id for (ks, keyspace_id) in base_map.items()}
-
-
-    def __get_cluster_metadata(self, cluster):
-        hosts = cluster.metadata.all_hosts()
-        unique_dcs = self.__unique((host.datacenter for host in hosts))
-        return {"host-count": len(hosts), "dc-count": sum(1 for i in unique_dcs)}
-
-
-    def each_keyspace(self, ks_fn):
-        for (ks, keyspace_id) in self.keyspaces.items():
-            ks_fn(ks, keyspace_id)
+        self.keyspaces = self.get_keyspaces(cluster, props)
+        self.metadata = self.get_common_metadata(cluster, props)
 
 
     def export_metadata(self):

--- a/python/adelphi/adelphi/cql.py
+++ b/python/adelphi/adelphi/cql.py
@@ -27,6 +27,11 @@ class CqlExporter(BaseExporter):
         self.metadata = self.get_common_metadata(cluster, props)
 
 
+    def each_keyspace(self, ks_fn):
+        for (ks, keyspace_id) in self.keyspaces.items():
+            ks_fn(ks, keyspace_id)
+
+
     def export_metadata(self):
         return {k : self.metadata[k] for k in self.metadata.keys() if self.metadata[k]}
 
@@ -44,3 +49,7 @@ class CqlExporter(BaseExporter):
                       .replace("CREATE KEYSPACE", "CREATE KEYSPACE IF NOT EXISTS") \
                       .replace("CREATE TYPE", "CREATE TYPE IF NOT EXISTS") \
                       .replace("CREATE INDEX", "CREATE INDEX IF NOT EXISTS")
+
+
+    def add_metadata(self, k, v):
+        self.metadata[k] = v

--- a/python/adelphi/adelphi/export.py
+++ b/python/adelphi/adelphi/export.py
@@ -89,7 +89,8 @@ class BaseExporter:
     def get_cluster_metadata(self, cluster):
         hosts = cluster.metadata.all_hosts()
         unique_dcs = self.__unique((host.datacenter for host in hosts))
-        return {"host-count": len(hosts), "dc-count": sum(1 for i in unique_dcs)}
+        unique_cass_vers = self.__unique((host.release_version for host in hosts))
+        return {"host-count": len(hosts), "dc-count": sum(1 for _ in unique_dcs), "cassandra-versions": ",".join(unique_cass_vers)}
 
 
     def get_common_metadata(self, cluster, props):

--- a/python/adelphi/adelphi/export.py
+++ b/python/adelphi/adelphi/export.py
@@ -1,0 +1,100 @@
+# Copyright DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import hashlib
+import logging
+from base64 import urlsafe_b64encode
+from datetime import datetime, tzinfo, timedelta
+
+try:
+    from itertools import ifilterfalse as filterfalse
+except ImportError:
+    from itertools import filterfalse
+
+from adelphi import NoKeyspacesSelectedException
+from adelphi.anonymize import anonymize_keyspace
+from adelphi.store import build_keyspace_objects
+
+
+log = logging.getLogger('adelphi')
+
+try:
+    from datetime import timezone
+    utc = timezone.utc
+except ImportError:
+    class UTC(tzinfo):
+        def utcoffset(self, dt):
+            return timedelta(0)
+        def tzname(self, dt):
+            return "UTC"
+        def dst(self, dt):
+            return timedelta(0)
+    utc = UTC()
+
+class BaseExporter:
+    
+    # unique_everseen from itertools recipes
+    def __unique(self, iterable, key=None):
+        "List unique elements, preserving order. Remember all elements ever seen."
+        # unique_everseen('AAAABBBCCDAABBB') --> A B C D
+        # unique_everseen('ABBCcAD', str.lower) --> A B C D
+        seen = set()
+        seen_add = seen.add
+        if key is None:
+            for element in filterfalse(seen.__contains__, iterable):
+                seen_add(element)
+                yield element
+        else:
+            for element in iterable:
+                k = key(element)
+                if k not in seen:
+                    seen_add(k)
+                    yield element
+
+
+    def build_keyspace_id(self, ks):
+        m = hashlib.sha256()
+        m.update(ks.name.encode("utf-8"))
+        # Leverage the urlsafe base64 encoding defined in RFC 4648, section 5 to provide an ID which can
+        # safely be used for filenames as well
+        return urlsafe_b64encode(m.digest()).decode('ascii')
+
+
+    def get_keyspaces(self, cluster, props):
+        keyspace_names = props["keyspace-names"]
+        metadata = cluster.metadata
+        keyspaces = build_keyspace_objects(keyspace_names, metadata)
+
+        if len(keyspaces) == 0:
+            raise NoKeyspacesSelectedException
+
+        log.info("Processing the following keyspaces: %s", ','.join((ks.name for ks in keyspaces)))
+
+        # anonymize_keyspace mutates keyspace state so we must trap keyspace_id before we (possibly) call it
+        base_map = { ks : self.build_keyspace_id(ks) for ks in keyspaces}
+        return base_map if not props['anonymize'] else {anonymize_keyspace(ks) : keyspace_id for (ks, keyspace_id) in base_map.items()}
+
+
+    def get_cluster_metadata(self, cluster):
+        hosts = cluster.metadata.all_hosts()
+        unique_dcs = self.__unique((host.datacenter for host in hosts))
+        return {"host-count": len(hosts), "dc-count": sum(1 for i in unique_dcs)}
+
+
+    def get_common_metadata(self, cluster, props):
+        metadata = {k : props[k] for k in ["purpose", "maturity"] if k in props}
+        metadata.update(self.get_cluster_metadata(cluster))
+        metadata["creation_timestamp"] = datetime.now(utc).isoformat()
+        return metadata
+        

--- a/python/adelphi/adelphi/export.py
+++ b/python/adelphi/adelphi/export.py
@@ -90,7 +90,7 @@ class BaseExporter:
         hosts = cluster.metadata.all_hosts()
         unique_dcs = self.__unique((host.datacenter for host in hosts))
         unique_cass_vers = self.__unique((host.release_version for host in hosts))
-        return {"host-count": len(hosts), "dc-count": sum(1 for _ in unique_dcs), "cassandra-versions": ",".join(unique_cass_vers)}
+        return {"host_count": len(hosts), "dc_count": sum(1 for _ in unique_dcs), "cassandra_versions": ",".join(unique_cass_vers)}
 
 
     def get_common_metadata(self, cluster, props):

--- a/python/adelphi/adelphi/gemini.py
+++ b/python/adelphi/adelphi/gemini.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 
-# Logic necessary to generate a string representation of a Gemini schema
-
 import json
 
 from cassandra.cqltypes import cqltype_to_python
@@ -42,8 +40,10 @@ class GeminiExporter(BaseExporter):
             self.keyspace_id = keyspace_id
 
 
-    def each_keyspace(self, ks_fn):
-        ks_fn(self.keyspace, self.keyspace_id)
+    def export_all(self):
+        # Exported Gemini schema is a formatted JSON doc and we don't have any way to add
+        # metadata/comments to that... so unfortunately this is the best we can do.
+        return self.export_schema()
 
 
     def export_metadata(self):
@@ -52,6 +52,10 @@ class GeminiExporter(BaseExporter):
 
     def export_schema(self):
         return self.__build_schema()
+
+
+    def each_keyspace(self, ks_fn):
+        ks_fn(self.keyspace, self.keyspace_id)
 
 
     def __build_schema(self):

--- a/python/adelphi/bin/adelphi
+++ b/python/adelphi/bin/adelphi
@@ -158,6 +158,8 @@ def export_cql(ctx, no_metadata):
     """Export a schema as raw CQL statements"""
 
     ctx.obj["include-metadata"] = not no_metadata
+    if no_metadata and ctx.obj["output-dir"]:
+        log.info("Metadata is always persisted to a separate metadata file when writing to an output directory")
 
     try:
         exporter = build_exporter(CqlExporter, ctx.obj)
@@ -171,6 +173,9 @@ def export_cql(ctx, no_metadata):
 @click.pass_context
 def export_gemini(ctx):
     """Export a schema in a format suitable for use with the the Gemini data integrity test framework"""
+
+    ctx.obj["include-metadata"] = True
+
     try:
         exporter = build_exporter(GeminiExporter, ctx.obj)
         export_keyspaces(ctx.obj, exporter)

--- a/python/adelphi/bin/adelphi
+++ b/python/adelphi/bin/adelphi
@@ -122,7 +122,7 @@ def export_keyspaces(props, exporter):
     export_dir = props["output-dir"]
 
     if export_dir is None:
-        print(exporter.export_all())
+        print(exporter.export_all() if props["include-metadata"] else exporter.export_schema())
     else:
         def ks_fn(keyspace_obj, keyspace_id):
             # Output filename should use the file-safe alphabet for b64 encoding
@@ -152,9 +152,13 @@ def export_keyspaces(props, exporter):
 
 # ============================ Command implementations ============================
 @export.command()
+@click.option('--no-metadata', help="Disable display of metadata when writing to standard out", is_flag=True)
 @click.pass_context
-def export_cql(ctx):
+def export_cql(ctx, no_metadata):
     """Export a schema as raw CQL statements"""
+
+    ctx.obj["include-metadata"] = not no_metadata
+
     try:
         exporter = build_exporter(CqlExporter, ctx.obj)
         export_keyspaces(ctx.obj, exporter)

--- a/python/adelphi/bin/adelphi
+++ b/python/adelphi/bin/adelphi
@@ -122,7 +122,7 @@ def export_keyspaces(props, exporter):
     export_dir = props["output-dir"]
 
     if export_dir is None:
-        print(exporter.export_schema())
+        print(exporter.export_all())
     else:
         def ks_fn(keyspace_obj, keyspace_id):
             # Output filename should use the file-safe alphabet for b64 encoding

--- a/python/adelphi/bin/adelphi
+++ b/python/adelphi/bin/adelphi
@@ -15,47 +15,24 @@
 # limitations under the License.
 
 import argparse
-import hashlib
+import json
 import logging
 import os
 import os.path
 import sys
-from base64 import urlsafe_b64encode
-from datetime import datetime, tzinfo, timedelta
 from functools import partial
-
-try:
-    from itertools import ifilterfalse as filterfalse
-except ImportError:
-    from itertools import filterfalse
 
 try:
     from tempfile import TemporaryDirectory
 except ImportError:
     from backports.tempfile import TemporaryDirectory
 
-try:
-    from datetime import timezone
-    utc = timezone.utc
-except ImportError:
-    class UTC(tzinfo):
-        def utcoffset(self, dt):
-            return timedelta(0)
-        def tzname(self, dt):
-            return "UTC"
-        def dst(self, dt):
-            return timedelta(0)
-    utc = UTC()
-
-
 import click
 
-from adelphi.anonymize import anonymize_keyspace
-from adelphi.cql import export_cql_schema
-from adelphi.gemini import export_gemini_schema
+from adelphi.cql import CqlExporter, NoKeyspacesSelectedException
+from adelphi.gemini import GeminiExporter, TooManyKeyspacesException
 from adelphi.gh import build_github, build_origin_repo, build_branch, commit_schemas, build_pull_request
-from adelphi.store import build_keyspace_objects
-from adelphi.store import with_cluster as _with_cluster
+from adelphi.store import with_cluster
 
 logging.basicConfig(level=logging.INFO)
 log = logging.getLogger('adelphi')
@@ -131,83 +108,45 @@ def export(ctx, hosts, port, username, password, keyspaces, rf, no_anonymize, ou
     ctx.obj['purpose'] = purpose
     ctx.obj['maturity'] = maturity
 
-# ============================ Utility functions for commands ============================
-# unique_everseen from itertools recipes
-def unique(iterable, key=None):
-    "List unique elements, preserving order. Remember all elements ever seen."
-    # unique_everseen('AAAABBBCCDAABBB') --> A B C D
-    # unique_everseen('ABBCcAD', str.lower) --> A B C D
-    seen = set()
-    seen_add = seen.add
-    if key is None:
-        for element in filterfalse(seen.__contains__, iterable):
-            seen_add(element)
-            yield element
-    else:
-        for element in iterable:
-            k = key(element)
-            if k not in seen:
-                seen_add(k)
-                yield element
 
-
-def with_cluster(cluster_fn, props):
-    return _with_cluster(cluster_fn, **({k:props[k] for k in ["hosts", "port", "username", "password"]}))
-
-
-def build_keyspace_id(ks):
-    m = hashlib.sha256()
-    m.update(ks.name.encode("utf-8"))
-    # Leverage the urlsafe base64 encoding defined in RFC 4648, section 5 to provide an ID which can
-    # safely be used for filenames as well
-    return urlsafe_b64encode(m.digest()).decode('ascii')
-
-
-def get_keyspaces(props, cluster):
-    keyspace_names = props["keyspace-names"]
-    metadata = cluster.metadata
-    keyspaces = build_keyspace_objects(keyspace_names, metadata)
-
-    if len(keyspaces) == 0:
-        log.info("No valid keyspaces selected")
-        exit(1)
-
-    log.info("Processing the following keyspaces: %s", ','.join((ks.name for ks in keyspaces)))
-    base_map = { ks : build_keyspace_id(ks) for ks in keyspaces}
-    return {anonymize_keyspace(ks) if props['anonymize'] else ks : keyspace_id for (ks, keyspace_id) in base_map.items()}
-
-
-def get_cluster_metadata(cluster):
-    hosts = cluster.metadata.all_hosts()
-    unique_dcs = unique((host.datacenter for host in hosts))
-    return {"host-count": len(hosts), "dc-count": sum(1 for i in unique_dcs)}
-
-
-def build_keyspace_map_and_metadata(props):
+def build_exporter(exportclz, props):
     def build_fn(cluster):
-        metadata = {k : props[k] for k in ["purpose", "maturity"] if k in props}
-        metadata.update(get_cluster_metadata(cluster))
-        metadata["creation_timestamp"] = datetime.now(utc).isoformat()
-        return (get_keyspaces(props, cluster), {k : metadata[k] for k in metadata.keys() if metadata[k]})
+        return exportclz(cluster, props)
 
-    return with_cluster(build_fn, props)
+    return with_cluster(build_fn, **({k:props[k] for k in ["hosts", "port", "username", "password"]}))
 
 
-def export_keyspaces(props, export_fn, keyspace_map, metadata):
+def export_keyspaces(props, exporter):
     options = {'rf': props['rf']}
     export_dir = props["output-dir"]
 
     if export_dir is None:
-        print(export_fn(iter(keyspace_map.keys()), metadata, options))
+        print(exporter.export_schema())
     else:
-        for (keyspace_obj, keyspace_id) in keyspace_map.items():
+        def ks_fn(keyspace_obj, keyspace_id):
             # Output filename should use the file-safe alphabet for b64 encoding
-            output_file_name = keyspace_id if props["anonymize"] else keyspace_obj.name
-            with open(os.path.join(export_dir, output_file_name),'w') as output_file:
-                log.info("Writing schema for keyspace " + keyspace_obj.name + " to file " + output_file.name)
+            output_dir_name = keyspace_id if props["anonymize"] else keyspace_obj.name
+            output_dir = os.path.join(export_dir, output_dir_name)
+            if not os.path.exists(output_dir):
+                os.mkdir(output_dir)
+            elif not os.path.isdir(output_dir):
+                log.error("Specified output directory " + output_dir + " exists but is not a directory")
+                exit(4)
+            elif not os.access(output_dir, os.W_OK):
+                log.error("Output directory " + output_dir + " exists but is not writable")
+                exit(5)
+
+            with open(os.path.join(output_dir, "schema"),'w') as schema_file:
+                log.info("Writing schema for keyspace " + keyspace_obj.name + " to file " + schema_file.name)
+                schema_file.write(exporter.export_schema())
+
+            with open(os.path.join(output_dir, "metadata.json"),'w') as metadata_file:
+                log.info("Writing metadata for keyspace " + keyspace_obj.name + " to file " + metadata_file.name)
+                metadata = exporter.export_metadata()
                 metadata['keyspace_id'] = keyspace_id
-                output_file.write(export_fn(iter([keyspace_obj]), metadata, options))
-                del metadata['keyspace_id']
+                metadata_file.write(json.dumps(metadata))
+
+        exporter.each_keyspace(ks_fn)
 
 
 # ============================ Command implementations ============================
@@ -215,21 +154,27 @@ def export_keyspaces(props, export_fn, keyspace_map, metadata):
 @click.pass_context
 def export_cql(ctx):
     """Export a schema as raw CQL statements"""
-    (keyspace_map, metadata) = build_keyspace_map_and_metadata(ctx.obj)
-    export_keyspaces(ctx.obj, export_cql_schema, keyspace_map, metadata)
+    try:
+        exporter = build_exporter(CqlExporter, ctx.obj)
+        export_keyspaces(ctx.obj, exporter)
+    except NoKeyspacesSelectedException:
+        log.info("No valid keyspaces selected")
+        exit(1)
 
 
 @export.command()
 @click.pass_context
 def export_gemini(ctx):
     """Export a schema in a format suitable for use with the the Gemini data integrity test framework"""
-    (keyspace_map, metadata) = build_keyspace_map_and_metadata(ctx.obj)
-
-    if len(keyspace_map) > 1:
+    try:
+        exporter = build_exporter(GeminiExporter, ctx.obj)
+        export_keyspaces(ctx.obj, exporter)
+    except NoKeyspacesSelectedException:
+        log.info("No valid keyspaces selected")
+        exit(1)
+    except TooManyKeyspacesException:
         log.error("Gemini schema doesn't support multiple keyspaces.")
         exit(2)
-
-    export_keyspaces(ctx.obj, export_gemini_schema, keyspace_map, metadata)
 
 
 @export.command()

--- a/python/adelphi/bin/adelphi
+++ b/python/adelphi/bin/adelphi
@@ -29,7 +29,8 @@ except ImportError:
 
 import click
 
-from adelphi.cql import CqlExporter, NoKeyspacesSelectedException
+from adelphi import NoKeyspacesSelectedException
+from adelphi.cql import CqlExporter
 from adelphi.gemini import GeminiExporter, TooManyKeyspacesException
 from adelphi.gh import build_github, build_origin_repo, build_branch, commit_schemas, build_pull_request
 from adelphi.store import with_cluster

--- a/python/adelphi/bin/adelphi
+++ b/python/adelphi/bin/adelphi
@@ -126,22 +126,22 @@ def export_keyspaces(props, exporter):
     else:
         def ks_fn(keyspace_obj, keyspace_id):
             # Output filename should use the file-safe alphabet for b64 encoding
-            output_dir_name = keyspace_id if props["anonymize"] else keyspace_obj.name
-            output_dir = os.path.join(export_dir, output_dir_name)
-            if not os.path.exists(output_dir):
-                os.mkdir(output_dir)
-            elif not os.path.isdir(output_dir):
-                log.error("Specified output directory " + output_dir + " exists but is not a directory")
+            keyspace_dir_name = keyspace_id if props["anonymize"] else keyspace_obj.name
+            keyspace_dir = os.path.join(export_dir, keyspace_dir_name)
+            if not os.path.exists(keyspace_dir):
+                os.mkdir(keyspace_dir)
+            elif not os.path.isdir(keyspace_dir):
+                log.error("Specified output directory " + keyspace_dir + " exists but is not a directory")
                 exit(4)
-            elif not os.access(output_dir, os.W_OK):
-                log.error("Output directory " + output_dir + " exists but is not writable")
+            elif not os.access(keyspace_dir, os.W_OK):
+                log.error("Output directory " + keyspace_dir + " exists but is not writable")
                 exit(5)
 
-            with open(os.path.join(output_dir, "schema"),'w') as schema_file:
+            with open(os.path.join(keyspace_dir, "schema"),'w') as schema_file:
                 log.info("Writing schema for keyspace " + keyspace_obj.name + " to file " + schema_file.name)
                 schema_file.write(exporter.export_schema())
 
-            with open(os.path.join(output_dir, "metadata.json"),'w') as metadata_file:
+            with open(os.path.join(keyspace_dir, "metadata.json"),'w') as metadata_file:
                 log.info("Writing metadata for keyspace " + keyspace_obj.name + " to file " + metadata_file.name)
                 metadata = exporter.export_metadata()
                 metadata['keyspace_id'] = keyspace_id
@@ -197,10 +197,9 @@ def contribute(ctx, token):
         props = ctx.obj.copy()
         props["output-dir"] = tmpdir
 
-        (keyspace_map, metadata) = build_keyspace_map_and_metadata(ctx.obj)
-        metadata["github_user"] = gh.get_user().login
-
-        export_keyspaces(props, export_cql_schema, keyspace_map, metadata)
+        exporter = build_exporter(CqlExporter, props)
+        exporter.add_metadata("github_user", gh.get_user().login)
+        export_keyspaces(props, exporter)
 
         if not sys.version_info[0] == 3:
             patch_repo(origin_repo)

--- a/python/adelphi/integration-tests/adelphi-docker-tests.sh
+++ b/python/adelphi/integration-tests/adelphi-docker-tests.sh
@@ -77,8 +77,7 @@ mkdir -p output logs
 rm -rf output/* logs/*
 
 # C* versions to test with (these must be available Docker images in dockerhub)
-#versions=(2.1.22 2.2.19 3.0.23 3.11.9 4.0-beta3)
-versions=(2.1.22)
+versions=(2.1.22 2.2.19 3.0.23 3.11.9 4.0-beta3)
 
 allPass=""
 for v in "${versions[@]}"

--- a/python/adelphi/integration-tests/adelphi-docker-tests.sh
+++ b/python/adelphi/integration-tests/adelphi-docker-tests.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-exitCode=0
-
 function start() {
 	local version=$1
 	echo "Starting C* $version"
@@ -31,24 +29,41 @@ function create_schema() {
 	docker exec -it adelphi cqlsh -e "`cat base-schema.cql`" >> logs/$version.log
 }
 
-function anonymize() {
+function export_schema() {
 	local version=$1
-	echo "Anonymizing..."
-	adelphi export-cql > output/$version.cql 2>> logs/$version.log
+	echo "Exporting schemas for comparison..."
+	adelphi export-cql --no-metadata > output/$version-stdout.cql 2>> logs/$version.log
+	mkdir output/$version
+	adelphi --output-dir=output/$version export-cql 2>> logs/$version.log
+}
+
+function _do_diff() {
+        local schemaFile=$1
+	echo "Comparing schemas/${version}.cql to $schemaFile..."
+        diff -Z schemas/$version.cql $schemaFile
+}
+
+function _check_diff_return() {
+	local diffExitCode=$1
+	if [ $diffExitCode -ne 0 ]; then
+	        echo "ERROR: CQL schema comparison failed for C* $version"
+	fi
+	return $diffExitCode
 }
 
 function compare() {
-	local version=$1
-	echo "Comparing..."
-	diff schemas/$version.cql output/$version.cql
-	diffExitCode=$?
-	if [ $diffExitCode -ne 0 ]; then
-		echo "ERROR: CQL schema comparison failed for C* $version"
-		exitCode=$diffExitCode
-	else
-		echo "Comparison OK"
+        local version=$1
+        _do_diff "output/${version}-stdout.cql"
+	_check_diff_return $?
+	local rv1=$?
+	_do_diff `find output/${version} -name schema`
+	_check_diff_return $?
+	local rv2=$?
+	if [ $rv1 -eq 0 ] && [ $rv2 -eq 0 ]; then
+	    echo "All comparisons matched, schemas look good!"
+	    return 0
 	fi
-
+	return 1
 }
 
 # build adelphi package
@@ -59,17 +74,27 @@ pip install ../../adelphi
 mkdir -p output logs
 
 # clear previous results
-rm output/* logs/*
+rm -rf output/* logs/*
 
 # C* versions to test with (these must be available Docker images in dockerhub)
-versions=(2.1.22 2.2.19 3.0.23 3.11.9 4.0-beta3)
+#versions=(2.1.22 2.2.19 3.0.23 3.11.9 4.0-beta3)
+versions=(2.1.22)
+
+allPass=""
 for v in "${versions[@]}"
 do
 	start $v
 	create_schema $v
-	anonymize $v
+	export_schema $v
 	compare $v
+	if [ $? -ne 0 ]; then
+	    allPass=false
+	fi
 	stop $v
 done
 
-exit $exitCode
+if [ ! $allPass ]; then
+    exit 0
+else
+    exit 1
+fi

--- a/python/adelphi/integration-tests/schemas/2.1.22.cql
+++ b/python/adelphi/integration-tests/schemas/2.1.22.cql
@@ -1,7 +1,3 @@
-//Schema metadata:
-//@host_count = 1
-//@dc_count = 1
-
 CREATE KEYSPACE IF NOT EXISTS ks_0 WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'}  AND durable_writes = true;
 
 CREATE TYPE IF NOT EXISTS ks_0.udt_0 (

--- a/python/adelphi/integration-tests/schemas/2.2.19.cql
+++ b/python/adelphi/integration-tests/schemas/2.2.19.cql
@@ -1,7 +1,3 @@
-//Schema metadata:
-//@host_count = 1
-//@dc_count = 1
-
 CREATE KEYSPACE IF NOT EXISTS ks_0 WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'}  AND durable_writes = true;
 
 CREATE TYPE IF NOT EXISTS ks_0.udt_0 (

--- a/python/adelphi/integration-tests/schemas/3.0.23.cql
+++ b/python/adelphi/integration-tests/schemas/3.0.23.cql
@@ -1,7 +1,3 @@
-//Schema metadata:
-//@host_count = 1
-//@dc_count = 1
-
 CREATE KEYSPACE IF NOT EXISTS ks_0 WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'}  AND durable_writes = true;
 
 CREATE TYPE IF NOT EXISTS ks_0.udt_0 (

--- a/python/adelphi/integration-tests/schemas/3.11.9.cql
+++ b/python/adelphi/integration-tests/schemas/3.11.9.cql
@@ -1,7 +1,3 @@
-//Schema metadata:
-//@host_count = 1
-//@dc_count = 1
-
 CREATE KEYSPACE IF NOT EXISTS ks_0 WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'}  AND durable_writes = true;
 
 CREATE TYPE IF NOT EXISTS ks_0.udt_0 (

--- a/python/adelphi/integration-tests/schemas/4.0-beta3.cql
+++ b/python/adelphi/integration-tests/schemas/4.0-beta3.cql
@@ -1,7 +1,3 @@
-//Schema metadata:
-//@host_count = 1
-//@dc_count = 1
-
 CREATE KEYSPACE IF NOT EXISTS ks_0 WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'}  AND durable_writes = true;
 
 CREATE TYPE IF NOT EXISTS ks_0.udt_0 (


### PR DESCRIPTION
Moving away from metadata + schema in a single file and towards a directory containing all materials for a given schema with raw schema output (in either CQL or Gemini format) in one file and metadata (in JSON) stored in a separate file underneath that directory.
