### PR TITLE
#64 Results storage simplified

### DIFF
--- a/helm/adelphi/templates/cassandra-diff-results.yaml
+++ b/helm/adelphi/templates/cassandra-diff-results.yaml
@@ -13,7 +13,7 @@ spec:
       command: ["sh", "-c", "-e"]
       args:
         - VERSION=$(wget -q -O - https://storage.googleapis.com/kubernetes-release/release/stable.txt 2> /dev/null);
-          OUTPUT=/results/cassandra-diff;
+          OUTPUT=/results;
           wget -q -O /usr/sbin/kubectl https://storage.googleapis.com/kubernetes-release/release/$VERSION/bin/linux/amd64/kubectl;
           pip install cassandra-driver;
           chmod +x /usr/sbin/kubectl;

--- a/helm/adelphi/templates/cassandra-diff-results.yaml
+++ b/helm/adelphi/templates/cassandra-diff-results.yaml
@@ -38,3 +38,6 @@ spec:
     - name: config
       configMap:
         name: cassandra-diff-configmap
+    - name: results-pv
+      persistentVolumeClaim:
+        claimName: cassandra-diff-pvc

--- a/helm/adelphi/templates/gemini-job.yaml
+++ b/helm/adelphi/templates/gemini-job.yaml
@@ -71,3 +71,6 @@ spec:
         items:
         - key: password
           path: password
+    - name: results-pv
+      persistentVolumeClaim:
+        claimName: gemini-pvc

--- a/helm/adelphi/templates/gemini-job.yaml
+++ b/helm/adelphi/templates/gemini-job.yaml
@@ -25,7 +25,7 @@ spec:
           --test-password="`cat /target-secret/password`"
           --duration={{ .Values.gemini_test_duration }}
           --schema=/workspace/gemini_schema.json
-          --outfile=/results/gemini/results.txt
+          --outfile=/results/results.txt
       dnsConfig:
         options:
         - name: ndots

--- a/helm/adelphi/templates/nosqlbench-jobs.yaml
+++ b/helm/adelphi/templates/nosqlbench-jobs.yaml
@@ -12,7 +12,7 @@ spec:
       image: nosqlbench/nosqlbench:latest
       args: [
         "--show-stacktraces",
-        "--report-csv-to=/results/nosqlbench-source",
+        "--report-csv-to=/results",
         "/config/workload.yaml",
         "hosts={{ .Values.source.clusterName }}-{{ .Values.source.dc }}-service",
         "username={{ .Values.source.clusterName }}-superuser",
@@ -49,7 +49,7 @@ spec:
       image: nosqlbench/nosqlbench:latest
       args: [
         "--show-stacktraces",
-        "--report-csv-to=/results/nosqlbench-target",
+        "--report-csv-to=/results",
         "/config/workload.yaml",
         "hosts={{ .Values.target.clusterName }}-{{ .Values.target.dc }}-service",
         "username={{ .Values.target.clusterName }}-superuser",

--- a/helm/adelphi/templates/nosqlbench-jobs.yaml
+++ b/helm/adelphi/templates/nosqlbench-jobs.yaml
@@ -41,6 +41,9 @@ spec:
     - name: workload
       configMap:
         name: nosqlbench-workload-configmap
+    - name: results-pv
+      persistentVolumeClaim:
+        claimName: nosqlbench-source-pvc
   - name: nosqlbench-target
     container:
       image: nosqlbench/nosqlbench:latest
@@ -75,3 +78,6 @@ spec:
     - name: workload
       configMap:
         name: nosqlbench-workload-configmap
+    - name: results-pv
+      persistentVolumeClaim:
+        claimName: nosqlbench-target-pvc

--- a/helm/adelphi/templates/pvc.yaml
+++ b/helm/adelphi/templates/pvc.yaml
@@ -9,7 +9,7 @@ spec:
   storageClassName: {{ .Values.storageClassName }}
   resources:
     requests:
-      storage: 100Mi
+      storage: 20Mi
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -22,7 +22,7 @@ spec:
   storageClassName: {{ .Values.storageClassName }}
   resources:
     requests:
-      storage: 100Mi
+      storage: 20Mi
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -35,7 +35,7 @@ spec:
   storageClassName: {{ .Values.storageClassName }}
   resources:
     requests:
-      storage: 100Mi
+      storage: 20Mi
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -48,5 +48,5 @@ spec:
   storageClassName: {{ .Values.storageClassName }}
   resources:
     requests:
-      storage: 100Mi
+      storage: 20Mi
 ---

--- a/helm/adelphi/templates/pvc.yaml
+++ b/helm/adelphi/templates/pvc.yaml
@@ -1,0 +1,52 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: gemini-pvc
+  namespace: {{ .Values.namespace }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: {{ .Values.storageClassName }}
+  resources:
+    requests:
+      storage: 100Mi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: nosqlbench-source-pvc
+  namespace: {{ .Values.namespace }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: {{ .Values.storageClassName }}
+  resources:
+    requests:
+      storage: 100Mi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: nosqlbench-target-pvc
+  namespace: {{ .Values.namespace }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: {{ .Values.storageClassName }}
+  resources:
+    requests:
+      storage: 100Mi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: cassandra-diff-pvc
+  namespace: {{ .Values.namespace }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: {{ .Values.storageClassName }}
+  resources:
+    requests:
+      storage: 100Mi
+---

--- a/helm/adelphi/templates/results-server.yaml
+++ b/helm/adelphi/templates/results-server.yaml
@@ -15,6 +15,7 @@ spec:
         kind: Pod
         metadata:
           name: results-server
+          namespace: {{ .Values.namespace }}
           ownerReferences:
           - apiVersion: argoproj.io/v1alpha1
             blockOwnerDeletion: true

--- a/helm/adelphi/templates/results-server.yaml
+++ b/helm/adelphi/templates/results-server.yaml
@@ -8,27 +8,47 @@ metadata:
 spec:
   templates:
   - name: results-server
-    daemon: true
-    container:
-      image: nginx
-      volumeMounts:
-      - name: config
-        mountPath: /etc/nginx/conf.d
-      - name: results-pv
-        mountPath: /results
-    initContainers:
-    - name: clear-index
-      image: alpine
-      command:
-        - sh
-        - -c
-      args:
-        # remove sample index created by the NFS server
-        - rm -f /results/index.html
-      volumeMounts:
-      - name: results-pv
-        mountPath: /results
-    volumes:
-    - name: config
-      configMap:
-        name: results-server-configmap
+    resource:
+      action: create
+      manifest: |
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          name: results-server
+          ownerReferences:
+          - apiVersion: argoproj.io/v1alpha1
+            blockOwnerDeletion: true
+            kind: Workflow
+            name: "{{`{{workflow.name}}`}}"
+            uid: "{{`{{workflow.uid}}`}}"
+        spec:
+          containers:
+          - name : nginx
+            image: nginx
+            volumeMounts:
+            - name: config
+              mountPath: /etc/nginx/conf.d
+            - name: gemini
+              mountPath: /results/gemini
+            - name: nosqlbench-source
+              mountPath: /results/nosqlbench-source
+            - name: nosqlbench-target
+              mountPath: /results/nosqlbench-target
+            - name: cassandra-diff
+              mountPath: /results/cassandra-diff
+          volumes:
+          - name: config
+            configMap:
+              name: results-server-configmap
+          - name: gemini
+            persistentVolumeClaim:
+              claimName: gemini-pvc
+          - name: nosqlbench-source
+            persistentVolumeClaim:
+              claimName: nosqlbench-source-pvc
+          - name: nosqlbench-target
+            persistentVolumeClaim:
+              claimName: nosqlbench-target-pvc
+          - name: cassandra-diff
+            persistentVolumeClaim:
+              claimName: cassandra-diff-pvc

--- a/helm/adelphi/templates/workflow-adelphi.yaml
+++ b/helm/adelphi/templates/workflow-adelphi.yaml
@@ -5,14 +5,6 @@ metadata:
 spec:
   entrypoint: execute
   serviceAccountName: cass-operator
-  volumeClaimTemplates:
-  - metadata:
-      name: results-pv
-    spec:
-      accessModes: [ "ReadWriteOnce" ]
-      resources:
-        requests:
-          storage: 1Gi
   templates:
   - name: execute
     dag:


### PR DESCRIPTION
The original intent of #64 was to make the storage configurable to work around a specific issue: being able to write the result files simultaneously from different pods and make it work across k8s envs (local or Cloud). So, the main idea was that for k3d the user could use local storage and on GKE he could provision an NFS server (Google Filestore).

Instead, the solution I'm proposition here achieves the same goals (parallel writes and cross-env compatibility) while being self-contained (no NFS or other external service required).

The way it works is that each job (gemini, cassandra-diff, nosqlbench) gets a dedicated PVC and in the end of the workflow these same PVCs are all mounted by the webserver (nginx) to expose the files to the client, which can then be download and stored somewhere else. The webserver is kept running after the Argo Workflow exits, but it will be terminated when the Helm chart is deleted.

