### PR TITLE
#36 Added example values.yaml for GKE.

### DIFF
--- a/helm/adelphi/gke-values.yaml
+++ b/helm/adelphi/gke-values.yaml
@@ -1,0 +1,7 @@
+############################ 
+# Config overrides for GKE 
+############################
+
+storageClassName: standard
+
+clusterSize: 3


### PR DESCRIPTION
The default values.yaml bundled in Adelphi will assume local execution with k3d and as such the `storageClassName` config will remain `local-path` and `clusterSize` set to 1.

In this PR we're providing an example config for running on GKE, which overrides the `storageClassName` to `standard` and `clusterSize` to 3.

In order to run with the new config file, add the `-f` flag to the Helm install command, like this:

```
helm install adelphi helm/adelphi -n cass-operator -f helm/adelphi/gke-values.yaml
```