### PR TITLE
#129 Make `rampup-cycles` and `main-cycles` be NB template vars again.

### DIFF
--- a/helm/adelphi/templates/nosqlbench-jobs.yaml
+++ b/helm/adelphi/templates/nosqlbench-jobs.yaml
@@ -17,6 +17,8 @@ spec:
         "/workspace/nosqlbench_source.yaml",
         "source",
         "scenarioname=source",
+        "rampup-cycles={{ .Values.nosqlbench_cycles }}",
+        "main-cycles={{ .Values.nosqlbench_cycles }}",
         "hosts={{ .Values.source.clusterName }}-{{ .Values.source.dc }}-service",
         "username={{ .Values.source.clusterName }}-superuser",
         "passfile=/secret/password"
@@ -39,7 +41,7 @@ spec:
       command: ["sh", "-c", "-e"]
       args:
         - pip install adelphi;
-          adelphi --hosts="{{ .Values.source.clusterName }}-{{ .Values.source.dc }}-service" --username="{{ .Values.source.clusterName }}-superuser" --password="`cat /secret/password`" --keyspaces="{{ .Values.gemini_schema_keyspace }}" --no-anonymize export-nb --rampup-cycles="{{ .Values.nosqlbench_cycles }}" --main-cycles="{{ .Values.nosqlbench_cycles }}" > /workspace/nosqlbench_source.yaml;
+          adelphi --hosts="{{ .Values.source.clusterName }}-{{ .Values.source.dc }}-service" --username="{{ .Values.source.clusterName }}-superuser" --password="`cat /secret/password`" --keyspaces="{{ .Values.gemini_schema_keyspace }}" --no-anonymize export-nb > /workspace/nosqlbench_source.yaml;
           cat /workspace/nosqlbench_source.yaml;
       volumeMounts:
       - name: workspace
@@ -69,6 +71,8 @@ spec:
         "/workspace/nosqlbench_target.yaml",
         "target",
         "scenarioname=target",
+        "rampup-cycles={{ .Values.nosqlbench_cycles }}",
+        "main-cycles={{ .Values.nosqlbench_cycles }}",
         "hosts={{ .Values.target.clusterName }}-{{ .Values.target.dc }}-service",
         "username={{ .Values.target.clusterName }}-superuser",
         "passfile=/secret/password",
@@ -92,7 +96,7 @@ spec:
       command: ["sh", "-c", "-e"]
       args:
         - pip install adelphi;
-          adelphi --hosts="{{ .Values.target.clusterName }}-{{ .Values.target.dc }}-service" --username="{{ .Values.target.clusterName }}-superuser" --password="`cat /secret/password`" --keyspaces="{{ .Values.gemini_schema_keyspace }}" --no-anonymize export-nb --rampup-cycles="{{ .Values.nosqlbench_cycles }}" --main-cycles="{{ .Values.nosqlbench_cycles }}" > /workspace/nosqlbench_target.yaml;
+          adelphi --hosts="{{ .Values.target.clusterName }}-{{ .Values.target.dc }}-service" --username="{{ .Values.target.clusterName }}-superuser" --password="`cat /secret/password`" --keyspaces="{{ .Values.gemini_schema_keyspace }}" --no-anonymize export-nb > /workspace/nosqlbench_target.yaml;
           cat /workspace/nosqlbench_target.yaml;
       volumeMounts:
       - name: workspace

--- a/python/adelphi/adelphi/nb.py
+++ b/python/adelphi/adelphi/nb.py
@@ -7,8 +7,8 @@ from adelphi.exceptions import KeyspaceSelectionException, TableSelectionExcepti
 from adelphi.export import BaseExporter
 
 MAX_NUMERIC_VAL = 1000 ** 3
-RAMPUP_SCENARIO = "run driver=cql tags=phase:rampup cycles={} threads=auto"
-MAIN_SCENARIO = "run driver=cql tags=phase:main cycles={} threads=auto"
+RAMPUP_SCENARIO = "run driver=cql tags=phase:rampup cycles=TEMPLATE(rampup-cycles,{}) threads=auto"
+MAIN_SCENARIO = "run driver=cql tags=phase:main cycles=TEMPLATE(main-cycles,{}) threads=auto"
 
 CQL_TYPES={}
 CQL_TYPES["text"] = "Mod({}); ToString() -> String"

--- a/python/adelphi/tests/integration/resources/nb-schemas/2.1.22.yaml
+++ b/python/adelphi/tests/integration/resources/nb-schemas/2.1.22.yaml
@@ -39,5 +39,5 @@ blocks:
     type: write
 scenarios:
   TEMPLATE(scenarioname,default):
-  - run driver=cql tags=phase:rampup cycles=1000 threads=auto
-  - run driver=cql tags=phase:main cycles=1000 threads=auto
+  - run driver=cql tags=phase:rampup cycles=TEMPLATE(rampup-cycles,1000) threads=auto
+  - run driver=cql tags=phase:main cycles=TEMPLATE(main-cycles,1000) threads=auto

--- a/python/adelphi/tests/integration/resources/nb-schemas/2.2.19.yaml
+++ b/python/adelphi/tests/integration/resources/nb-schemas/2.2.19.yaml
@@ -39,5 +39,5 @@ blocks:
     type: write
 scenarios:
   TEMPLATE(scenarioname,default):
-  - run driver=cql tags=phase:rampup cycles=1000 threads=auto
-  - run driver=cql tags=phase:main cycles=1000 threads=auto
+  - run driver=cql tags=phase:rampup cycles=TEMPLATE(rampup-cycles,1000) threads=auto
+  - run driver=cql tags=phase:main cycles=TEMPLATE(main-cycles,1000) threads=auto

--- a/python/adelphi/tests/integration/resources/nb-schemas/3.0.23.yaml
+++ b/python/adelphi/tests/integration/resources/nb-schemas/3.0.23.yaml
@@ -39,5 +39,5 @@ blocks:
     type: write
 scenarios:
   TEMPLATE(scenarioname,default):
-  - run driver=cql tags=phase:rampup cycles=1000 threads=auto
-  - run driver=cql tags=phase:main cycles=1000 threads=auto
+  - run driver=cql tags=phase:rampup cycles=TEMPLATE(rampup-cycles,1000) threads=auto
+  - run driver=cql tags=phase:main cycles=TEMPLATE(main-cycles,1000) threads=auto

--- a/python/adelphi/tests/integration/resources/nb-schemas/3.11.10.yaml
+++ b/python/adelphi/tests/integration/resources/nb-schemas/3.11.10.yaml
@@ -39,5 +39,5 @@ blocks:
     type: write
 scenarios:
   TEMPLATE(scenarioname,default):
-  - run driver=cql tags=phase:rampup cycles=1000 threads=auto
-  - run driver=cql tags=phase:main cycles=1000 threads=auto
+  - run driver=cql tags=phase:rampup cycles=TEMPLATE(rampup-cycles,1000) threads=auto
+  - run driver=cql tags=phase:main cycles=TEMPLATE(main-cycles,1000) threads=auto

--- a/python/adelphi/tests/integration/resources/nb-schemas/4.0-rc1.yaml
+++ b/python/adelphi/tests/integration/resources/nb-schemas/4.0-rc1.yaml
@@ -39,5 +39,5 @@ blocks:
     type: write
 scenarios:
   TEMPLATE(scenarioname,default):
-  - run driver=cql tags=phase:rampup cycles=1000 threads=auto
-  - run driver=cql tags=phase:main cycles=1000 threads=auto
+  - run driver=cql tags=phase:rampup cycles=TEMPLATE(rampup-cycles,1000) threads=auto
+  - run driver=cql tags=phase:main cycles=TEMPLATE(main-cycles,1000) threads=auto


### PR DESCRIPTION
This will require a new pypi release to become effective.